### PR TITLE
Changes based on meeting with the Collab Lab

### DIFF
--- a/Dissertation/dissertation.tex
+++ b/Dissertation/dissertation.tex
@@ -28,7 +28,13 @@
 \usepackage{amssymb}   % allows the use of AMS symbols like blackboard bold
 \usepackage{graphicx}  % for including graphics files and images
 \usepackage{caption}
+\captionsetup[table]{labelsep=space}
+\captionsetup[figure]{labelsep=space}
 \usepackage{epstopdf}
+\usepackage{tocloft}
+\setlength{\cftbeforetoctitleskip}{-25pt}
+\setlength{\cftbeforeloftitleskip}{-25pt}
+\setlength{\cftbeforelottitleskip}{-25pt}
 \usepackage{times}     % Times New Roman (nimbus version)
 \usepackage{listings}  % allows program codes embeded with original forms
 \usepackage{bookmark}  % make it possible to add PDF bookmarks at will
@@ -101,8 +107,10 @@
 \pdfbookmark[section]{\contentsname}{toc}  % put toc in PDF bookmarks
 \tableofcontents
 \pagebreak
+\pdfbookmark[section]{LIST OF FIGURES}{figures}
 \listoffigures
 \pagebreak
+\pdfbookmark[section]{LIST OF TABLES}{tables}
 \listoftables
 
 % preface section is optional


### PR DESCRIPTION
1. Remove colons from all captions so that the captions on figures and
tables match those in List of Figures and List of
Tables. Alternatively, one could add colons to all the items in the
List of Figures, but I chose this solution.

2. Remove margin between the Table of Contents, List of Figures, and
List of Tables so that it matches the margins on the Abstract page and
other preceeding pages. I just eyeballed the length that it needs to
be moved up so I'm not totally sure

3. Add pdf bookmarks for the List of Figures and List of Tables.